### PR TITLE
Feature: Organized the Key dropdown when adding rules in the admin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,6 +27,11 @@ The rule class must have the following attributes:
   fields: a dictionary of field_names, and django form classes. This declares
           the parameters available.
 
+The following optional attribute is available:
+  category: a grouping used as the header of an option group in the Key dropdown
+            in the admin to make it easier to organize rules.
+            If a category is not provided, the rule defaults to "uncategorized'.
+
 Additionally, the rule class must accept a rule_model and model_to_check
 as initialization arguments, and have a run method that accepts
 *args and **kwargs.

--- a/example/sample/dynamic_actions.py
+++ b/example/sample/dynamic_actions.py
@@ -19,8 +19,9 @@ class SampleRuleOne(BaseDynamicAction):
 
     def run(self, *args, **kwargs):
         if self.trigger_model.value > self.max_value:
-            print "\n\nValue must be less than or equal to %d. Your value was %d\n\n" % \
-                  (self.max_value, self.trigger_model.value)
+            print("\n\nValue must be less than or equal to %d. Your value was %d\n\n" %
+                  (self.max_value, self.trigger_model.value))
+
 
 @rule_registry.register
 class SampleRuleTwo(BaseDynamicAction):
@@ -34,8 +35,30 @@ class SampleRuleTwo(BaseDynamicAction):
 
     def run(self, *args, **kwargs):
         if not (self.x_value <= self.trigger_model.value <= self.y_value):
-            print "\n\nValue must be between %d and %d. Your value was %d\n\n" % \
-                  (self.x_value, self.y_value, self.trigger_model.value)
+            print("\n\nValue must be between %d and %d. Your value was %d\n\n" %
+                  (self.x_value, self.y_value, self.trigger_model.value))
+
+
+@rule_registry.register
+class SampleRuleThree(BaseDynamicAction):
+    key = "SampleRuleThree"
+    display_name = "A sample rule."
+    category = "Category A"
+
+
+@rule_registry.register
+class SampleRuleFour(BaseDynamicAction):
+    key = "SampleRuleFour"
+    display_name = "Another sample rule."
+    category = "Category A"
+
+
+@rule_registry.register
+class SampleRuleFive(BaseDynamicAction):
+    key = "SampleRuleFive"
+    display_name = "Yet another sample rule."
+    category = "Category B"
+
 
 @receiver(db.models.signals.post_save, sender=ModelToCheck, dispatch_uid="check_rules")
 def model_post_save(sender, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ TEST_REQUIREMENTS = [
 
 setup(
     name="django-dynamic-rules",
-    version="0.6.0",
+    version="0.7.0",
     author="IMT Computer Services",
     author_email="webadmin@imtapps.com",
     description="Allows you to create dynamic rules related to a particular model",


### PR DESCRIPTION
Previously, rule classes were in no particular order in the Key dropdown in the admin. This made it very difficult to find a rule when many were available.

This commit adds an optional "category" attribute that can be added to rules. The category is used as an optgroup in the select dropdown in the admin.

Additionally, rules are now in alphabetical order in the admin (within category).
